### PR TITLE
Removed Smagorinsky model from WaterLily simulation

### DIFF
--- a/Waterlily/smoke_wake.jl
+++ b/Waterlily/smoke_wake.jl
@@ -160,9 +160,6 @@ function record_animation(sim, params=PARAMS;
     iso=100,
     kwargs...)
 
-    (; Cs) = params
-    (; Δ, udf, λ) = derived_params(params)
-
     # Allocate SGS arrays
     S = prepare_sgs(sim, params)
 
@@ -197,8 +194,7 @@ function record_animation(sim, params=PARAMS;
         exposure=exposure, tonemap=tonemap, gamma=gamma) do (i, t)
 
         # Advance simulation
-        sim_step!(sim, t; remeasure=false, λ, udf,
-                  νₜ=smagorinsky, S, Cs, Δ)
+        sim_step!(sim, t; remeasure=false)
         # Extract, preprocess, and pad vorticity (must match padded dimensions)
         vort = extract_vorticity(sim)
         vort_clean = preprocess_vorticity(vort;

--- a/common/waterlily_simulation.jl
+++ b/common/waterlily_simulation.jl
@@ -19,10 +19,6 @@ const PARAMS = (
     Re = 3700,                  # Reynolds number
     U = 1,                      # Freestream velocity
 
-    # SGS model
-    explicit_sgs = true,        # Use explicit Smagorinsky SGS model
-    Cs = 0.17f0,               # Smagorinsky constant
-
     # Timing (in CTU - convective time units)
     time_max = 200,            # Total simulation time
     stats_init = 100,          # Time to start collecting statistics
@@ -44,15 +40,8 @@ const PARAMS = (
 derived_params(p) = (
     m = 3 * 2^p.p,
     R = (3 * 2^p.p) ÷ 3,
-    Δ = sqrt(3.0f0),           # Filter width √(1² + 1² + 1²)
-    udf = p.explicit_sgs ? sgs! : nothing,
-    λ = p.explicit_sgs ? cds : quick,
     fname_base = joinpath(p.datadir, "p$(p.p)"),
 )
-
-# SGS model
-smagorinsky(I::CartesianIndex{m} where m; S, Cs, Δ) =
-    @views (Cs * Δ)^2 * sqrt(2dot(S[I, :, :], S[I, :, :]))
 
 # Sphere geometry
 function make_sphere(m; n=5m ÷ 2, R=m ÷ 3, U=1, Re=3700, T=Float32, mem=Array)


### PR DESCRIPTION
We noticed that the WaterLily simulation shows some funky stuff on the inflow. Removing the Smagorinsky model and running with the default schemes solves this. I realise this is also the case in our [ThreeD_SphereLESBiotSavart.jl](https://github.com/WaterLily-jl/WaterLily-Examples/blob/435284a85c93d63f13c68a07403069cc1909d6e3/examples/ThreeD_SphereLESBiotSavart.jl) example. So I will look into that too, but that's just on our end ;)

This PR is untested. Let me know if you have any problem when running it again. Also, could be nice to have a higher resolution (if possible :)!